### PR TITLE
Reset category list to empty only initially.

### DIFF
--- a/lib/backends/localStorage.js
+++ b/lib/backends/localStorage.js
@@ -13,7 +13,9 @@ var LocalStorageBackend = function(options) {
     this.storage = localStorage;
   }
 
-  this.storage[this.prefix + '.cats'] = '{}';
+  if (!this.storage[this.prefix + '.cats']) {
+    this.storage[this.prefix + '.cats'] = '{}';
+  }
 }
 
 LocalStorageBackend.prototype = {


### PR DESCRIPTION
Hey there,

the localStorage backend currently always resets the category list to {} upon initialization.  That way however you can't just start classifying after instantiation, since the list is empty.

I've wrapped the statement with an if-clause.  Firefox returns `null` for unset keys and Chrome `undefined`, therefore I just test it to evaluate to false.

How to regenerate classifier.min.js?  I didn't find a npm target or so.  For the moment I've patched the minified version, but that's just painful :-)

cheers,
  stesie
