### PR TITLE
Add Cyrilic Support

### DIFF
--- a/lib/bayesian.js
+++ b/lib/bayesian.js
@@ -56,7 +56,7 @@ Bayesian.prototype = {
     if (_(doc).isArray()) {
       return doc;
     }
-    var words = doc.split(/\W+/);
+    var words = doc.split(/[^a-zA-ZA-Яa-я0-9_]+/);
     return _(words).uniq();
   },
 


### PR DESCRIPTION
Sadly does not support UTF-8. The problem lies here:

``` javascript
getWords : function(doc) {
    if (_(doc).isArray()) {
      return doc;
    }
    var words = doc.split(/\W+/);
    return _(words).uniq();
  }
```

``` javascript
doc.split(/\W+/);
```

does not seem to work for UTF-8

Here is an example with Cyrilic language (like Russian):

``` javascript
"Надежда за обич еп.36 Тест".split(/\W+/);
```

This returns:

``` javascript
[ "", "36", "" ]
```

Instead should return something like this: 

``` javascript
[ "Надежда", "за", "обич", "еп", "36", "Тест"]
```

Fix is provided below:

Replace 

```
\/W+\
```

 with 

```
/[^a-zA-ZA-Яa-я0-9_]+/
```

 for cyrilic support.
